### PR TITLE
Little fix change class Fieldset to public

### DIFF
--- a/Sources/jumpper/HTML/Elements/Fieldset.swift
+++ b/Sources/jumpper/HTML/Elements/Fieldset.swift
@@ -43,7 +43,7 @@ import Foundation
      fieldset.add(labelAge)
     ````
 */
-final class Fieldset: GenericElement {
+public final class Fieldset: GenericElement {
     ///Override tag element for element. Default is `fieldset`
     override var tag: String {
         get {


### PR DESCRIPTION
Little fix change class Fieldset to public.


### Usage Example: ###
    ````
     let fieldset = Fieldset()

     let labelName = Label("Name")
     labelName.addAttribute(("for", "nameField"))
     fieldset.add(labelName)

     let inputName = InputText("", id: "nameField", placeholder: "Name")
     fieldset.add(inputName)
     
     let labelAge = Label("Age Range")
     labelAge.addAttribute(("for", "ageRangeField"))
     fieldset.add(labelAge)
    ````